### PR TITLE
서버 API 수정에 따른 변경사항

### DIFF
--- a/Allecords/Allecords/Data/DTO/ProductDTO.swift
+++ b/Allecords/Allecords/Data/DTO/ProductDTO.swift
@@ -8,17 +8,23 @@
 import Foundation
 
 struct ProductResponseDTO: Decodable {
+	let id: UInt
+	let aladinId: UInt
 	let title: String
 	let artist: String
 	let url: String
 	let imageURL: String
-	let price: String
+	let price: Double
+	let active: Int
 	
 	enum CodingKeys: String, CodingKey {
+		case id
+		case aladinId
 		case title
 		case artist
 		case url
-		case imageURL = "image_url"
+		case imageURL = "imageUrl"
 		case price
+		case active
 	}
 }

--- a/Allecords/Allecords/Data/Repositories/DefualtHomeRepository.swift
+++ b/Allecords/Allecords/Data/Repositories/DefualtHomeRepository.swift
@@ -18,7 +18,7 @@ final class DefaultHomeRepository {
 
 extension DefaultHomeRepository: HomeRepository {
 	enum Constant {
-		static let baseUrl = "https://allecords.shop/api2/products/"
+		static let baseUrl = "https://allecords.shop/api2/products"
 	}
 	
 	func fetchProductItems(page: Int) async throws -> [Product] {

--- a/Allecords/Allecords/Data/Repositories/DefualtHomeRepository.swift
+++ b/Allecords/Allecords/Data/Repositories/DefualtHomeRepository.swift
@@ -18,7 +18,7 @@ final class DefaultHomeRepository {
 
 extension DefaultHomeRepository: HomeRepository {
 	enum Constant {
-		static let baseUrl = "https://allecords.shop/api/products/"
+		static let baseUrl = "https://allecords.shop/api2/products/"
 	}
 	
 	func fetchProductItems(page: Int) async throws -> [Product] {

--- a/Allecords/Allecords/Domain/Entities/Product.swift
+++ b/Allecords/Allecords/Domain/Entities/Product.swift
@@ -12,5 +12,5 @@ struct Product {
 	let artist: String
 	let url: String
 	let imgUrl: String
-	let price: String
+	let price: Double
 }

--- a/Allecords/Allecords/Scenes/TabBarScene/HomeScene/BetweenScene/BetweenViewModel.swift
+++ b/Allecords/Allecords/Scenes/TabBarScene/HomeScene/BetweenScene/BetweenViewModel.swift
@@ -36,7 +36,7 @@ private extension BetweenViewModel {
 			.withUnretained(self)
 			.flatMap { (owner, _) -> AnyPublisher<Result<[Product], Error>, Never> in
 				let future = Future(asyncFunc: {
-					await owner.homeUseCase.fetchCrawlingProducts(with: 1)
+					await owner.homeUseCase.fetchCrawlingProducts(with: 0)
 				})
 				return future.eraseToAnyPublisher()
 			}

--- a/Allecords/Allecords/Scenes/TabBarScene/HomeScene/BetweenScene/View/ProductCell.swift
+++ b/Allecords/Allecords/Scenes/TabBarScene/HomeScene/BetweenScene/View/ProductCell.swift
@@ -32,7 +32,7 @@ final class ProductCell: UICollectionViewCell {
       imageView.loadImage(from: imageUrl.absoluteString)
     }
     nameLabel.text = product.title
-    priceLabel.text = product.price + " 원"
+    priceLabel.text = String(Int(product.price)) + " 원"
     newLabel.isHidden = false
   }
 }


### PR DESCRIPTION
# 변경사항

- 서버 분리되었습니다. Django, Spring 각각 돌아가는 부분이 다릅니다.
- api2라고 명시된 부분이 Spring 서버입니다
- DTO 값도 향후 사용자가 등록할 엔티티 고려하여 변경되었습니다 확인 바랍니다
- 쿼리 파라미터 시작값 1 -> 0 으로 수정했습니다

## 변경된 DTO
```swift
struct ProductResponseDTO: Decodable {
	let id: UInt // 상품 id
	let aladinId: UInt // 알라딘 id
	let title: String
	let artist: String
	let url: String
	let imageURL: String
	let price: Double
	let active: Int // 판매가능 상태
	
	enum CodingKeys: String, CodingKey {
		case id
		case aladinId
		case title
		case artist
		case url
		case imageURL = "imageUrl"
		case price
		case active
	}
}

```